### PR TITLE
Locking version of omnipay/common for compatiable reasons

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
     }
   },
   "require": {
-    "omnipay/common": "master"
+    "omnipay/common": "^v2.5.1"
   },
   "require-dev": {
     "guzzle/plugin-mock": "~3.1",
     "mockery/mockery": "~0.8",
-    "omnipay/tests": "master",
+    "omnipay/tests": "2.1.0",
     "phpunit/phpunit": "~3.7.16",
-    "squizlabs/php_codesniffer": "~1.4.4"
+    "squizlabs/php_codesniffer": "^1.4.4"
   },
   "extra": {
     "branch-alias": {


### PR DESCRIPTION
- Locking version of omnipay/common for compatiable reasons