### PR TITLE
Fix error adding string and integer

### DIFF
--- a/src/Helpers/CpfAndCnpjValidator.php
+++ b/src/Helpers/CpfAndCnpjValidator.php
@@ -74,7 +74,7 @@ class CpfAndCnpjValidator
         $n = 11;
         for ($i = 0; $i <= 9; $i++) {
             $n = $n - 1;
-            $sum = $sum + (substr($cpf_valid, $i, 1) * $n);
+            $sum = $sum + ((int)substr($cpf_valid, $i, 1) * $n);
         };
 
         $rest = $sum % 11;
@@ -89,7 +89,7 @@ class CpfAndCnpjValidator
         $n = 12;
         for ($i = 0; $i <= 10; $i++) {
             $n = $n - 1;
-            $sum = $sum + (substr($cpf_valid, $i, 1) * $n);
+            $sum = $sum + ((int)substr($cpf_valid, $i, 1) * $n);
         };
 
         $rest = $sum % 11;


### PR DESCRIPTION
Omnipay-adyen was broken under PHP-7.1+, when adding String and Integer:

`A non-numeric value encountered`

Thats because of [changes done on PHP-7.1][php-7-1-changes]

The fix is convert the string to integer instead of coercing it when
adding.

[php-7-1-changes]: http://php.net/manual/en/migration71.other-changes.php